### PR TITLE
Set Content-Type: application/json on requests

### DIFF
--- a/texoid/server.py
+++ b/texoid/server.py
@@ -72,6 +72,10 @@ def latex_to_dvi(filename):
 
 
 class MainHandler(tornado.web.RequestHandler):
+    def set_default_headers(self):
+        super(MainHandler, self).set_default_headers()
+        self.set_header('Content-Type', 'application/json')
+
     def handle_request(self):
         try:
             data = urllib.unquote(self.get_argument('q'))


### PR DESCRIPTION
This should improve interoperability with e.g. JQuery. Addresses #5.